### PR TITLE
Replace sfValidatorEmail with php builtin filter_var function

### DIFF
--- a/lib/validator/sfValidatorEmail.class.php
+++ b/lib/validator/sfValidatorEmail.class.php
@@ -18,16 +18,16 @@
  */
 class sfValidatorEmail extends sfValidatorBase
 {
-	/**
-	 * @see sfValidatorBase
-	 */
-	protected function doClean($value)
-	{
-		$clean = filter_var($value, FILTER_VALIDATE_EMAIL);
-		if (!$clean)
-		{
-			throw new sfValidatorError($this, 'invalid', array('value' => $value));
-		}
-		return $clean;
-	}
+  /**
+   * @see sfValidatorBase
+   */
+  protected function doClean($value)
+  {
+    $clean = filter_var($value, FILTER_VALIDATE_EMAIL);
+    if (!$clean)
+    {
+      throw new sfValidatorError($this, 'invalid', array('value' => $value));
+    }
+    return $clean;
+  }
 }

--- a/lib/validator/sfValidatorEmail.class.php
+++ b/lib/validator/sfValidatorEmail.class.php
@@ -16,17 +16,18 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-class sfValidatorEmail extends sfValidatorRegex
+class sfValidatorEmail extends sfValidatorBase
 {
-  const REGEX_EMAIL = '/^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i';
-
-  /**
-   * @see sfValidatorRegex
-   */
-  protected function configure($options = array(), $messages = array())
-  {
-    parent::configure($options, $messages);
-
-    $this->setOption('pattern', self::REGEX_EMAIL);
-  }
+	/**
+	 * @see sfValidatorBase
+	 */
+	protected function doClean($value)
+	{
+		$clean = filter_var($value, FILTER_VALIDATE_EMAIL);
+		if (!$clean)
+		{
+			throw new sfValidatorException($this, 'invalid', array('value' => $value));
+		}
+		return $clean;
+	}
 }

--- a/lib/validator/sfValidatorEmail.class.php
+++ b/lib/validator/sfValidatorEmail.class.php
@@ -26,7 +26,7 @@ class sfValidatorEmail extends sfValidatorBase
 		$clean = filter_var($value, FILTER_VALIDATE_EMAIL);
 		if (!$clean)
 		{
-			throw new sfValidatorException($this, 'invalid', array('value' => $value));
+			throw new sfValidatorError($this, 'invalid', array('value' => $value));
 		}
 		return $clean;
 	}


### PR DESCRIPTION
As this fork of Symfony1 depends on PHP 5.3 or greater, it is a good idea to use the PHP builtin function. The original implementation is at least as good as the Symfony regular expression and improves over the PHP versions.
