### PR TITLE
Use Drak's fork of Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "files": ["autoload.php"]
     },
     "suggest": {
-        "lexpress/doctrine1": "Doctrine plugin",
+        "drak/doctrine1": "Doctrine plugin",
         "propel/sf-propel-o-r-m-plugin": "Propel plugin"
     },
     "extra": {


### PR DESCRIPTION
Drak's fork is by far the [most popular on Packagist](https://packagist.org/search/?q=doctrine1).
It sounds like a good idea to consolidate community maintenance efforts on a single fork.
In particular the maintainer of a [strong fork by Recras](https://github.com/Recras/doctrine1) has already agreed to join in to the Drak's version.
Perhaps there is no need to maintain an LExpress' own version?