### PR TITLE
Add context to logger

### DIFF
--- a/lib/log/sfAggregateLogger.class.php
+++ b/lib/log/sfAggregateLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -36,7 +36,7 @@ class sfAggregateLogger extends sfLogger
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
     $this->dispatcher = $dispatcher;
-    
+
     if (isset($options['loggers']))
     {
       if (!is_array($options['loggers']))
@@ -91,11 +91,11 @@ class sfAggregateLogger extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
     foreach ($this->loggers as $logger)
     {
-      $logger->log($message, $priority);
+      $logger->log($message, $priority, $context);
     }
   }
 
@@ -106,7 +106,7 @@ class sfAggregateLogger extends sfLogger
   {
     foreach ($this->loggers as $logger)
     {
-      if($logger instanceof sfLogger) 
+      if($logger instanceof sfLogger)
       {
         $logger->shutdown();
       }

--- a/lib/log/sfEventLogger.class.php
+++ b/lib/log/sfEventLogger.class.php
@@ -27,7 +27,7 @@ class sfEventLogger extends sfLogger
   /**
    * {@inheritDoc}
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
     $this->dispatcher->notify(new sfEvent($this, 'command.log', array($message)));
   }

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -90,7 +90,7 @@ class sfFileLogger extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
     flock($this->fp, LOCK_EX);
     fwrite($this->fp, strtr($this->format, array(

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -75,7 +75,7 @@ abstract class sfLogger implements sfLoggerInterface
   {
     $this->dispatcher = $dispatcher;
     $this->options = $options;
-    
+
     if (isset($this->options['level']))
     {
       $this->setLogLevel($this->options['level']);
@@ -83,7 +83,7 @@ abstract class sfLogger implements sfLoggerInterface
 
     $dispatcher->connect('application.log', array($this, 'listenToLogEvent'));
   }
-  
+
   /**
    * Returns the options for the logger instance.
    */
@@ -91,7 +91,7 @@ abstract class sfLogger implements sfLoggerInterface
   {
     return $this->options;
   }
-  
+
   /**
    * Returns the options for the logger instance.
    */
@@ -131,14 +131,14 @@ abstract class sfLogger implements sfLoggerInterface
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  public function log($message, $priority = self::INFO)
+  public function log($message, $priority = self::INFO, array $context = array())
   {
     if ($this->getLogLevel() < $priority)
     {
       return false;
     }
 
-    return $this->doLog($message, $priority);
+    return $this->doLog($message, $priority, $context);
   }
 
   /**
@@ -147,16 +147,16 @@ abstract class sfLogger implements sfLoggerInterface
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  abstract protected function doLog($message, $priority);
+  abstract protected function doLog($message, $priority, array $context = array());
 
   /**
    * Logs an emerg message.
    *
    * @param string $message Message
    */
-  public function emerg($message)
+  public function emerg($message, array $context = array())
   {
-    $this->log($message, self::EMERG);
+    $this->log($message, self::EMERG, $context);
   }
 
   /**
@@ -164,9 +164,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function alert($message)
+  public function alert($message, array $context = array())
   {
-    $this->log($message, self::ALERT);
+    $this->log($message, self::ALERT, $context);
   }
 
   /**
@@ -174,9 +174,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function crit($message)
+  public function crit($message, array $context = array())
   {
-    $this->log($message, self::CRIT);
+    $this->log($message, self::CRIT, $context);
   }
 
   /**
@@ -184,9 +184,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function err($message)
+  public function err($message, array $context = array())
   {
-    $this->log($message, self::ERR);
+    $this->log($message, self::ERR, $context);
   }
 
   /**
@@ -194,9 +194,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function warning($message)
+  public function warning($message, array $context = array())
   {
-    $this->log($message, self::WARNING);
+    $this->log($message, self::WARNING, $context);
   }
 
   /**
@@ -204,9 +204,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function notice($message)
+  public function notice($message, array $context = array())
   {
-    $this->log($message, self::NOTICE);
+    $this->log($message, self::NOTICE, $context);
   }
 
   /**
@@ -214,9 +214,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function info($message)
+  public function info($message, array $context = array())
   {
-    $this->log($message, self::INFO);
+    $this->log($message, self::INFO, $context);
   }
 
   /**
@@ -224,9 +224,9 @@ abstract class sfLogger implements sfLoggerInterface
    *
    * @param string $message Message
    */
-  public function debug($message)
+  public function debug($message, array $context = array())
   {
-    $this->log($message, self::DEBUG);
+    $this->log($message, self::DEBUG, $context);
   }
 
   /**

--- a/lib/log/sfLoggerInterface.class.php
+++ b/lib/log/sfLoggerInterface.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -24,5 +24,5 @@ interface sfLoggerInterface
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  public function log($message, $priority = null);
+  public function log($message, $priority = null, array $context = array());
 }

--- a/lib/log/sfLoggerWrapper.class.php
+++ b/lib/log/sfLoggerWrapper.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -37,8 +37,8 @@ class sfLoggerWrapper extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
-    $this->logger->log($message, $priority);
+    $this->logger->log($message, $priority, $context);
   }
 }

--- a/lib/log/sfNoLogger.class.php
+++ b/lib/log/sfNoLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -36,7 +36,7 @@ class sfNoLogger extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
   }
 }

--- a/lib/log/sfPsrLoggerAdapter.class.php
+++ b/lib/log/sfPsrLoggerAdapter.class.php
@@ -122,7 +122,7 @@ class sfPsrLoggerAdapter extends sfLogger
    *
    * @return void
    */
-  public function doLog($message, $priority)
+  public function doLog($message, $priority, array $context = array())
   {
     if (!$this->logger)
     {
@@ -133,28 +133,28 @@ class sfPsrLoggerAdapter extends sfLogger
     switch ($priority)
     {
       case sfLogger::EMERG:
-        $this->logger->emergency($message);
+        $this->logger->emergency($message, $context);
         break;
       case sfLogger::ALERT:
-        $this->logger->alert($message);
+        $this->logger->alert($message, $context);
         break;
       case sfLogger::CRIT:
-        $this->logger->critical($message);
+        $this->logger->critical($message, $context);
         break;
       case sfLogger::ERR:
-        $this->logger->error($message);
+        $this->logger->error($message, $context);
         break;
       case sfLogger::WARNING:
-        $this->logger->warning($message);
+        $this->logger->warning($message, $context);
         break;
       case sfLogger::NOTICE:
-        $this->logger->notice($message);
+        $this->logger->notice($message, $context);
         break;
       case sfLogger::INFO:
-        $this->logger->info($message);
+        $this->logger->info($message, $context);
         break;
       case sfLogger::DEBUG:
-        $this->logger->debug($message);
+        $this->logger->debug($message, $context);
         break;
     }
   }

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -68,7 +68,7 @@ class sfStreamLogger extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
     fwrite($this->stream, $message.PHP_EOL);
     flush();

--- a/lib/log/sfVarLogger.class.php
+++ b/lib/log/sfVarLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -53,7 +53,7 @@ class sfVarLogger extends sfLogger
    * Each log entry has the following attributes:
    *
    *  * priority
-   *  * time   
+   *  * time
    *  * message
    *  * type
    *  * debugStack
@@ -132,7 +132,7 @@ class sfVarLogger extends sfLogger
    * @param string $message   Message
    * @param string $priority  Message priority
    */
-  protected function doLog($message, $priority)
+  protected function doLog($message, $priority, array $context = array())
   {
     // get log type in {}
     $type = 'sfOther';
@@ -156,7 +156,7 @@ class sfVarLogger extends sfLogger
    * Returns the debug stack.
    *
    * @return array
-   * 
+   *
    * @see debug_backtrace()
    */
   protected function getDebugBacktrace()


### PR DESCRIPTION
Bonjour,

J'ai rajouté la possibilité d'ajouter un context au logger, pour ce faire j'ai rajouté à la fonction ``doLog`` de ``sfLoggerInterface`` le paramètre ``$context`` qui lui est utilisé par tous les logger lors de l'implémentation de cette interface.

Je propose cette modification pour par exemple envoyer un context (variable etc..) vers sentry (par le biais de raven).

Exemple :
```
$this->getLogger()->err($e, array('variableTestToShow' => 'variableTestShow'));
```

J'ai ajouté cette fonctionnalité sur mes projets mais j'aimerais tout de même vous la proposer, c'est comme ça que symfony2 procède dans le ``Logger.php``

Qu'en pensez-vous ?

Cordialement.
