### PR TITLE
changed log level of sfException to CRITICAL (excluding 404 error)

### DIFF
--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -73,7 +73,7 @@ class sfException extends Exception
   {
   	self::$lastException = null;
   }
-  
+
   /**
    * Prints the stack trace for this exception.
    */
@@ -137,7 +137,8 @@ class sfException extends Exception
 
       if (sfConfig::get('sf_logging_enabled'))
       {
-        $dispatcher->notify(new sfEvent($exception, 'application.log', array($exception->getMessage(), 'priority' => sfLogger::ERR)));
+        $priority = $exception instanceof sfError404Exception ? sfLogger::ERR : sfLogger::CRIT;
+        $dispatcher->notify(new sfEvent($exception, 'application.log', array($exception->getMessage(), 'priority' => $priority)));
       }
 
       $event = $dispatcher->notifyUntil(new sfEvent($exception, 'application.throw_exception'));
@@ -195,9 +196,9 @@ class sfException extends Exception
       }
     }
 
-    // when using CLI, we force the format to be TXT. Compare exactly to  
-    // the string 'cli' because the php 5.4 server is identified by 'cli-server' 
-    if ('cli' == PHP_SAPI) 
+    // when using CLI, we force the format to be TXT. Compare exactly to
+    // the string 'cli' because the php 5.4 server is identified by 'cli-server'
+    if ('cli' == PHP_SAPI)
     {
       $format = 'txt';
     }
@@ -397,7 +398,7 @@ class sfException extends Exception
       {
         $formattedValue = $value;
       }
-      
+
       $result[] = is_int($key) ? $formattedValue : sprintf("'%s' => %s", self::escape($key), $formattedValue);
     }
 
@@ -406,12 +407,12 @@ class sfException extends Exception
 
   /**
    * Formats a file path.
-   * 
+   *
    * @param  string  $file   An absolute file path
    * @param  integer $line   The line number
    * @param  string  $format The output format (txt or html)
    * @param  string  $text   Use this text for the link rather than the file path
-   * 
+   *
    * @return string
    */
   static protected function formatFile($file, $line, $format = 'html', $text = null)
@@ -443,7 +444,7 @@ class sfException extends Exception
     {
       return $value;
     }
-    
+
     return htmlspecialchars($value, ENT_QUOTES, sfConfig::get('sf_charset', 'UTF-8'));
   }
 }


### PR DESCRIPTION
As Symfony2, I want to log as CRITICAL instead of ERR for thrown exception (except 404 error).
What do you think?