### PR TITLE
Revert "Makes sfAPCCache compatible with APCu"

### DIFF
--- a/lib/cache/sfAPCCache.class.php
+++ b/lib/cache/sfAPCCache.class.php
@@ -197,12 +197,9 @@ class sfAPCCache extends sfCache
 
     if (is_array($infos['cache_list']))
     {
-      // Compatibility with APCu PHP 5.5+
-      $infoKey = extension_loaded('apcu') ? 'key' : 'info';
-
       foreach ($infos['cache_list'] as $info)
       {
-        if ($this->getOption('prefix').$key == $info[$infoKey])
+        if ($this->getOption('prefix').$key == $info['info'])
         {
           return $info;
         }


### PR DESCRIPTION
Reverts LExpress/symfony1#94

Ensure you get the apcu [version >= 4.0.7](https://pecl.php.net/package-changelog.php?package=APCu&release=4.0.7)

