### PR TITLE
Fix integers used in mt_rand()

### DIFF
--- a/lib/task/generator/sfGenerateAppTask.class.php
+++ b/lib/task/generator/sfGenerateAppTask.class.php
@@ -118,7 +118,7 @@ EOF;
 
     if (true === $options['csrf-secret'])
     {
-      $options['csrf-secret'] = sha1(mt_rand(111111111, 99999999).getmypid());
+      $options['csrf-secret'] = sha1(mt_rand(11111111, 99999999).getmypid());
     }
 
     // Set no_script_name value in settings.yml for production environment


### PR DESCRIPTION
The first integer provided was larger than the second one which causes PHP to generate a warning. Have removed a 1 from the first integer to make it smaller than the second.