### PR TITLE
sfAutoload include: eval only if forced on HHVM

### DIFF
--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -138,7 +138,7 @@ class sfAutoload
 
     $file = $configuration->getConfigCache()->checkConfig('config/autoload.yml');
 
-    if (defined('HHVM_VERSION'))
+    if ($force && defined('HHVM_VERSION'))
     {
       // workaround for https://github.com/facebook/hhvm/issues/1447
       $this->classes = eval(str_replace('<?php', '', file_get_contents($file)));


### PR DESCRIPTION
it's a lot faster, can use opcode cache on hhvm