### PR TITLE
Save i18n message.xml target attribute in CDATA section

### DIFF
--- a/lib/i18n/sfMessageSource_XLIFF.class.php
+++ b/lib/i18n/sfMessageSource_XLIFF.class.php
@@ -197,7 +197,7 @@ class sfMessageSource_XLIFF extends sfMessageSource_File
       $source = $dom->createElement('source');
       $source->appendChild($dom->createTextNode($message));
       $target = $dom->createElement('target');
-      $target->appendChild($dom->createTextNode(''));
+      $target->appendChild($dom->createCDATASection(''));
 
       $unit->appendChild($source);
       $unit->appendChild($target);
@@ -277,7 +277,8 @@ class sfMessageSource_XLIFF extends sfMessageSource_File
           // set the new translated string
           if ($node->nodeName == 'target')
           {
-            $node->nodeValue = $target;
+            $node->nodeValue = '';            
+            $node->appendChild($dom->createCDATASection($target));
             $targetted = true;
           }
 
@@ -294,7 +295,7 @@ class sfMessageSource_XLIFF extends sfMessageSource_File
       if ($found && !$targetted)
       {
         $targetNode = $dom->createElement('target');
-        $targetNode->appendChild($dom->createTextNode($target));
+        $targetNode->appendChild($dom->createCDATASection($target));
         $unit->appendChild($targetNode);
       }
 


### PR DESCRIPTION
If you want to save HTML tag in messages.xml <target> attribute. You need to add this code to <![CDATA[]]> 
With this update, <target> attribute is automatically created with <![CDATA[]]> section.
For example:
```
<trans-unit id="1">
   <source>My contacts</source>
   <target><![CDATA[]]></target>
</trans-unit>
```
If you want to add HTML tag to <target>, just need to add:
```
<trans-unit id="1">
   <source>My contacts</source>
   <target><![CDATA[My<br> Contacts]]></target>
</trans-unit>
```
