### PR TITLE
sfWidgetFormSelectRadio/Checkbox fail to create correct choice widgets (especially with multibyte characters)

### DIFF
--- a/lib/widget/sfWidgetForm.class.php
+++ b/lib/widget/sfWidgetForm.class.php
@@ -252,8 +252,11 @@ abstract class sfWidgetForm extends sfWidget
       $name = sprintf($this->getOption('id_format'), $name);
     }
 
-    // remove illegal characters
-    $name = preg_replace(array('/^[^A-Za-z]+/', '/[^A-Za-z0-9\:_\.\-]/'), array('', '_'), $name);
+    // Hash $name if illegal characters are contained, instead of replacing them with '_'.
+    if (preg_match( '/([A-Za-z0-9\:_\.\-]*)([^A-Za-z0-9\:_\.\-])/', $name, $matches))
+    {
+      $name = $matches[1].substr(md5($matches[2]), 0, 8);
+    }
 
     return $name;
   }

--- a/lib/widget/sfWidgetFormSelectCheckbox.class.php
+++ b/lib/widget/sfWidgetFormSelectCheckbox.class.php
@@ -107,7 +107,7 @@ class sfWidgetFormSelectCheckbox extends sfWidgetFormChoiceBase
         $baseAttributes['checked'] = 'checked';
       }
 
-      $inputs[$id] = array(
+      $inputs[] = array(
         'input' => $this->renderTag('input', array_merge($baseAttributes, $attributes)),
         'label' => $this->renderContentTag('label', self::escapeOnce($option), array('for' => $id)),
       );

--- a/lib/widget/sfWidgetFormSelectRadio.class.php
+++ b/lib/widget/sfWidgetFormSelectRadio.class.php
@@ -102,7 +102,7 @@ class sfWidgetFormSelectRadio extends sfWidgetFormChoiceBase
         $baseAttributes['checked'] = 'checked';
       }
 
-      $inputs[$id] = array(
+      $inputs[] = array(
         'input' => $this->renderTag('input', array_merge($baseAttributes, $attributes)),
         'label' => $this->renderContentTag('label', self::escapeOnce($option), array('for' => $id)),
       );


### PR DESCRIPTION
Hello, guys.

I found the bugs especially important for non-ascii environments.
(I use sf1.5 on Japanese environment.)

Code example:
The code below creates only 1 OPTION element, instead of 2.
`
new sfWidgetFormInputChoice([
  'choices' => [
    '山田' => '山田', 
    '森田' => '森田'
]);
`

Problem 1:
sfWidgetForm::generateId() creates id simply replacing each illegall characters on name and value attributes with '_'. 
So it can create same id for different widgets (which have same length name and same length value) with multibyte characters.

`
$name = preg_replace(array('/^[^A-Za-z]+/', '/[^A-Za-z0-9\:_\.\-]/'), array('', '_'), $name);
`

But It should always create unique id.
Instead of simply replacing,  to hash the illegal characters is better, I think.

Problem 2:
sfWidgetFormSelectRadio/Checkbox expect that these ids are unique, and use them as key of $inputs[]. 

`$inputs[$id] = array( ...`

But when some keys of the 'choices' option have same length and are non-ascii characters,  they get same ids, so $inputs will be overrided and corrupted. 

Of course if problem#1 is solved, fixing problem#2 is not needed actually.
But in any case current code above is meaningless, I want to fix.

Thank you.
