### PR TITLE
Fix session data losing under certain situation

### DIFF
--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -398,6 +398,7 @@ class sfWebResponse extends sfResponse
 
     if (function_exists('fastcgi_finish_request'))
     {
+      $this->dispatcher->notify(new sfEvent($this, 'response.fastcgi_finish_request'));
       fastcgi_finish_request();
     }
   }


### PR DESCRIPTION
I'm facing the problem that session data is lost, in case using `sfPdoSessionStorage` on php-fpm.

If using the session storage having no locks feature such as `sfPdoSessionStorage`, the session data the redirect response creates may be lost in the next request. It's because the response invokes `fastcgi_finish_request` after sends contents, so next request comes immediately without ensuring session data has been persisted to storage.

So we should ensure the user/storage has been shut down before `fastcgi_finish_request` calling.

See: [SaveSessionListner](https://github.com/symfony/http-kernel/blob/402746c8dd74dfaca0994d2acd8a59e2a4df033f/EventListener/SaveSessionListener.php) of sf2