### PR TITLE
Fixed yaml dumpArray() for PHP 7.1

### DIFF
--- a/lib/yaml/sfYamlInline.class.php
+++ b/lib/yaml/sfYamlInline.class.php
@@ -134,7 +134,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', '$w = is_numeric($w) ? $w : 0; return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val)


### PR DESCRIPTION
The function `dumpArray()` returned warnings about non-numeric values in the inline function of the `array_reduce` call. This was fixed by adding an explicit check for a numeric value.

Run `php test/unit/yaml/sfYamlInlineTest.php` on PHP 7.1 to see the original problem and to verify my fix.