### PR TITLE
sfDoctrinePlugin: Check if validator keys are not associative

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/validator/sfValidatorDoctrineChoice.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/validator/sfValidatorDoctrineChoice.class.php
@@ -46,6 +46,7 @@ class sfValidatorDoctrineChoice extends sfValidatorBase
 
     $this->addMessage('min', 'At least %min% values must be selected (%count% values selected).');
     $this->addMessage('max', 'At most %max% values must be selected (%count% values selected).');
+    $this->addMessage('invalid_keys', 'Array keys must be numeric and consecutive');
   }
 
   /**
@@ -75,6 +76,11 @@ class sfValidatorDoctrineChoice extends sfValidatorBase
       }
 
       $count = count($value);
+
+      if (array_keys($value) !== range(0, $count-1))
+      {
+        throw new sfValidatorError($this, 'invalid_keys', array('keys' => array_keys($value)));
+      }
 
       if ($this->hasOption('min') && $count < $this->getOption('min'))
       {

--- a/lib/plugins/sfDoctrinePlugin/test/unit/validator/sfValidatorDoctrineChoiceTest.php
+++ b/lib/plugins/sfDoctrinePlugin/test/unit/validator/sfValidatorDoctrineChoiceTest.php
@@ -4,7 +4,7 @@ $app = 'frontend';
 $fixtures = 'fixtures/fixtures.yml';
 include dirname(__FILE__).'/../../bootstrap/functional.php';
 
-$t = new lime_test(1);
+$t = new lime_test(3);
 
 // ->clean()
 $t->diag('->clean()');
@@ -16,3 +16,17 @@ $author = Doctrine_Core::getTable('Author')->createQuery()->limit(1)->fetchOne()
 $validator->clean($author->id);
 
 $t->is(trim($query->getDql()), 'FROM Author', '->clean() does not change the supplied query object');
+
+$t->info('Presenting associative array to clean() function should throw error');
+$validator = new sfValidatorDoctrineChoice(array(
+  'model' => 'Author',
+  'multiple' => true,
+));
+$validator->setMessage('invalid_keys', 'invalid_keys');
+try {
+  $validator->clean(array('key' => 1));
+  $t->fail('->clean(), presented with associative array, should throw sfValidatorError');
+} catch(sfValidatorError $e) {
+  $t->pass('->clean(), presented with associative array, should throw sfValidatorError');
+  $t->is($e->getMessage(), 'invalid_keys', '->clean(), presented with associative array, should throw "invalid_keys" error');
+}


### PR DESCRIPTION
If the `sfValidatorDoctrineChoice` validator from sfDoctrinePlugin validates an associative array, the input is passed unqualified to `$query->andWhereIn()`, resulting in a PDO exception.