### PR TITLE
Ensure class is autoloaded by us

### DIFF
--- a/lib/config/sfFactoryConfigHandler.class.php
+++ b/lib/config/sfFactoryConfigHandler.class.php
@@ -217,7 +217,7 @@ class sfFactoryConfigHandler extends sfYamlConfigHandler
 
         case 'mailer':
           $instances[] = sprintf(
-                        "if (!class_exists('Swift')) {\n".
+                        "if (!class_exists('Swift'), false) {\n".
                         "  \$swift_dir = sfConfig::get('sf_swiftmailer_dir', sfConfig::get('sf_symfony_lib_dir').'/vendor/swiftmailer/lib');\n".
                         "  require_once \$swift_dir.'/swift_required.php';\n".
                         "}\n".


### PR DESCRIPTION
Currently this check tries to autoload the class, which in dev environment results in sfAutoloadAgain calling sfAutoload::reloadClasses(true) and regenerating everything every request even if nothing’s changed.