### PR TITLE
Don't try to autoload a trait if it's already been declared

### DIFF
--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -188,7 +188,7 @@ class sfAutoload
     $class = strtolower($class);
 
     // class already exists
-    if (class_exists($class, false) || interface_exists($class, false))
+    if (class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false))
     {
       return true;
     }

--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -188,7 +188,7 @@ class sfAutoload
     $class = strtolower($class);
 
     // class already exists
-    if (class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false))
+    if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false)))
     {
       return true;
     }


### PR DESCRIPTION
As of [version 1.5.7](https://github.com/LExpress/symfony1/blob/master/CHANGELOG.md#02022016-version-157), autoload of traits is supported. However, the `sfAutoload->loadClass()` method will fail if you're trying to autoload a trait that has been previously loaded. This won't happen with classes or interfaces, since that method will do nothing if the required class or interface is already registered (by calling `class_exists()` and `interface_exists()`).

This PR just calls `trait_exists()` too, so it won't fail when trying to load a trait that has been previously loaded.