### PR TITLE
Fix/php 7.2 deprecation warnings

### DIFF
--- a/lib/cache/sfMemcacheCache.class.php
+++ b/lib/cache/sfMemcacheCache.class.php
@@ -210,9 +210,12 @@ class sfMemcacheCache extends sfCache
   public function getMany($keys)
   {
     $values = array();
-    foreach ($this->memcache->get(array_map(create_function('$k', 'return "'.$this->getOption('prefix').'".$k;'), $keys)) as $key => $value)
+    $prefix = $this->getOption('prefix');
+    $prefixed_keys = array_map(function($k) use ($prefix) { return $prefix . $k; }, $keys);
+
+    foreach ($this->memcache->get($prefixed_keys) as $key => $value)
     {
-      $values[str_replace($this->getOption('prefix'), '', $key)] = $value;
+      $values[str_replace($prefix, '', $key)] = $value;
     }
 
     return $values;

--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -587,7 +587,12 @@ abstract class sfCommandApplication
     }
 
     // close the streams on script termination
-    register_shutdown_function(create_function('', 'fclose(STDIN); fclose(STDOUT); fclose(STDERR); return true;'));
+    register_shutdown_function(function() {
+        fclose(STDIN);
+        fclose(STDOUT);
+        fclose(STDERR);
+        return true;
+    });
   }
 
   /**

--- a/lib/config/sfConfigHandler.class.php
+++ b/lib/config/sfConfigHandler.class.php
@@ -75,7 +75,7 @@ abstract class sfConfigHandler
   {
     if (is_array($value))
     {
-      array_walk_recursive($value, create_function('&$value', '$value = sfToolkit::replaceConstants($value);'));
+      array_walk_recursive($value, function(& $value) { $value = sfToolkit::replaceConstants($value); });
     }
     else
     {
@@ -96,7 +96,7 @@ abstract class sfConfigHandler
   {
     if (is_array($path))
     {
-      array_walk_recursive($path, create_function('&$path', '$path = sfConfigHandler::replacePath($path);'));
+      array_walk_recursive($path, function(&$path) { $path = sfConfigHandler::replacePath($path); });
     }
     else
     {

--- a/lib/helper/TextHelper.php
+++ b/lib/helper/TextHelper.php
@@ -278,33 +278,24 @@ function _auto_link_urls($text, $href_options = array(), $truncate = false, $tru
 {
   $href_options = _tag_options($href_options);
 
-  $callback_function = '
-    if (preg_match("/<a\s/i", $matches[1]))
-    {
-      return $matches[0];
-    }
-    ';
-
-  if ($truncate)
-  {
-    $callback_function .= '
-      else if (strlen($matches[2].$matches[3]) > '.$truncate_len.')
+  $callback_function = function($matches) use ($href_options, $truncate, $truncate_len, $pad) {
+      if (preg_match("/<a\s/i", $matches[1]))
       {
-        return $matches[1].\'<a href="\'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].\'"'.$href_options.'>\'.substr($matches[2].$matches[3], 0, '.$truncate_len.').\''.$pad.'</a>\'.$matches[4];
+          return $matches[0];
       }
-      ';
-  }
-
-  $callback_function .= '
-    else
-    {
-      return $matches[1].\'<a href="\'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].\'"'.$href_options.'>\'.$matches[2].$matches[3].\'</a>\'.$matches[4];
-    }
-    ';
+      else if ($truncate && strlen($matches[2].$matches[3]) > $truncate_len)
+      {
+          return $matches[1].'<a href="'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].'"'.$href_options.'>'.substr($matches[2].$matches[3], 0, $truncate_len).$pad.'</a>'.$matches[4];
+      }
+      else
+      {
+          return $matches[1].'<a href="'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].'"'.$href_options.'>'.$matches[2].$matches[3].'</a>'.$matches[4];
+      }
+  };
 
   return preg_replace_callback(
     SF_AUTO_LINK_RE,
-    create_function('$matches', $callback_function),
+    $callback_function,
     $text
     );
 }

--- a/lib/helper/TextHelper.php
+++ b/lib/helper/TextHelper.php
@@ -283,14 +283,16 @@ function _auto_link_urls($text, $href_options = array(), $truncate = false, $tru
       {
           return $matches[0];
       }
-      else if ($truncate && strlen($matches[2].$matches[3]) > $truncate_len)
+
+      $text = $matches[2] . $matches[3];
+      $href = ($matches[2] == "www." ? "http://www." : $matches[2]) . $matches[3];
+
+      if ($truncate && strlen($text) > $truncate_len)
       {
-          return $matches[1].'<a href="'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].'"'.$href_options.'>'.substr($matches[2].$matches[3], 0, $truncate_len).$pad.'</a>'.$matches[4];
+          $text = substr($text, 0, $truncate_len).$pad;
       }
-      else
-      {
-          return $matches[1].'<a href="'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].'"'.$href_options.'>'.$matches[2].$matches[3].'</a>'.$matches[4];
-      }
+
+      return sprintf('%s<a href="%s"%s>%s</a>%s', $matches[1], $href, $href_options, $text, $matches[4]);
   };
 
   return preg_replace_callback(

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDeleteModelFilesTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDeleteModelFilesTask.class.php
@@ -76,7 +76,7 @@ EOF;
       {
         if (!$options['no-confirmation'] && !$this->askConfirmation(array_merge(
           array('The following '.$modelName.' files will be deleted:', ''),
-          array_map(create_function('$v', 'return \' - \'.sfDebug::shortenFilePath($v);'), $files),
+          array_map(function($v) { return ' - '.sfDebug::shortenFilePath($v); }, $files),
           array('', 'Continue? (y/N)')
         ), 'QUESTION_LARGE', false))
         {
@@ -100,10 +100,10 @@ EOF;
 
   /**
    * Converts an array of values to a regular expression pattern fragment.
-   * 
+   *
    * @param array  $values    An array of values for the pattern
    * @param string $delimiter The regular expression delimiter
-   * 
+   *
    * @return string A regular expression fragment
    */
   protected function valuesToRegex($values, $delimiter = '/')

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDropDbTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDropDbTask.class.php
@@ -73,7 +73,7 @@ EOF;
       &&
       !$this->askConfirmation(array_merge(
         array(sprintf('This command will remove all data in the following "%s" connection(s):', $environment), ''),
-        array_map(create_function('$v', 'return \' - \'.$v;'), array_keys($databases)),
+        array_map(function($v) { return ' - '.$v; }, array_keys($databases)),
         array('', 'Are you sure you want to proceed? (y/N)')
       ), 'QUESTION_LARGE', false)
     )

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineMigrateTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineMigrateTask.class.php
@@ -137,7 +137,7 @@ EOF;
       {
         $this->logBlock(array_merge(
           array('The following errors occurred:', ''),
-          array_map(create_function('$e', 'return \' - \'.$e->getMessage();'), $migration->getErrors())
+          array_map(function($e) { return ' - '.$e->getMessage(); }, $migration->getErrors())
         ), 'ERROR_LARGE');
       }
 

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -691,7 +691,7 @@ class sfRoute implements Serializable
       'extra_parameters_as_query_string' => true,
     ), $this->getDefaultOptions(), $this->options);
 
-    $preg_quote_hash = create_function('$a', 'return preg_quote($a, \'#\');');
+    $preg_quote_hash = function($a) { return preg_quote($a, '#'); };
 
     // compute some regexes
     $this->options['variable_prefix_regex'] = '(?:'.implode('|', array_map($preg_quote_hash, $this->options['variable_prefixes'])).')';
@@ -701,7 +701,7 @@ class sfRoute implements Serializable
       $this->options['segment_separators_regex'] = '(?:'.implode('|', array_map($preg_quote_hash, $this->options['segment_separators'])).')';
 
       // as of PHP 5.3.0, preg_quote automatically quotes dashes "-" (see http://bugs.php.net/bug.php?id=47229)
-      $preg_quote_hash_53 = create_function('$a', 'return str_replace(\'-\', \'\-\', preg_quote($a, \'#\'));');
+      $preg_quote_hash_53 = function($a) { return str_replace('-', '\-', preg_quote($a, '#')); };
       $this->options['variable_content_regex'] = '[^'.implode('',
           array_map(version_compare(PHP_VERSION, '5.3.0RC4', '>=') ? $preg_quote_hash : $preg_quote_hash_53, $this->options['segment_separators'])
         ).']+';

--- a/lib/task/project/sfProjectPermissionsTask.class.php
+++ b/lib/task/project/sfProjectPermissionsTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -72,18 +72,18 @@ EOF;
     {
       $this->logBlock(array_merge(
         array('Permissions on the following file(s) could not be fixed:', ''),
-        array_map(create_function('$f', 'return \' - \'.sfDebug::shortenFilePath($f);'), $this->failed)
+        array_map(function($f) { return ' - '.sfDebug::shortenFilePath($f); }, $this->failed)
       ), 'ERROR_LARGE');
     }
   }
 
   /**
    * Chmod and capture any failures.
-   * 
+   *
    * @param string  $file
    * @param integer $mode
    * @param integer $umask
-   * 
+   *
    * @see sfFilesystem
    */
   protected function chmod($file, $mode, $umask = 0000)
@@ -109,7 +109,7 @@ EOF;
 
   /**
    * Captures those chmod commands that fail.
-   * 
+   *
    * @see http://www.php.net/set_error_handler
    */
   public function handleError($no, $string, $file, $line, $context)

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -927,7 +927,7 @@ abstract class sfBrowserBase
     if (false !== $pos = strpos($name, '['))
     {
       $var = &$vars;
-      $tmps = array_filter(preg_split('/(\[ | \[\] | \])/x', $name), create_function('$s', 'return $s !== "";'));
+      $tmps = array_filter(preg_split('/(\[ | \[\] | \])/x', $name), function($s) { return $s !== ''; });
       foreach ($tmps as $tmp)
       {
         $var = &$var[$tmp];

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -283,8 +283,8 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   protected function updateCode()
   {
     $this->code = implode(' ', array_merge(
-      array_map(create_function('$e', 'return $e->getCode();'), $this->globalErrors),
-      array_map(create_function('$n,$e', 'return $n.\' [\'.$e->getCode().\']\';'), array_keys($this->namedErrors), array_values($this->namedErrors))
+      array_map(function($e) { /** @var $e sfValidatorError */ return $e->getCode(); }, $this->globalErrors),
+      array_map(function($n, $e) { /** @var $e sfValidatorError */ return $n.' ['.$e->getCode().']'; }, array_keys($this->namedErrors), array_values($this->namedErrors))
     ));
   }
 
@@ -294,8 +294,8 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   protected function updateMessage()
   {
     $this->message = implode(' ', array_merge(
-      array_map(create_function('$e', 'return $e->getMessage();'), $this->globalErrors),
-      array_map(create_function('$n,$e', 'return $n.\' [\'.$e->getMessage().\']\';'), array_keys($this->namedErrors), array_values($this->namedErrors))
+      array_map(function($e) { /** @var $e sfValidatorError */ return $e->getMessage(); }, $this->globalErrors),
+      array_map(function($n, $e) { /** @var $e sfValidatorError */ return $n.' ['.$e->getMessage().']'; }, array_keys($this->namedErrors), array_values($this->namedErrors))
     ));
   }
 

--- a/lib/validator/sfValidatorFromDescription.class.php
+++ b/lib/validator/sfValidatorFromDescription.class.php
@@ -294,7 +294,7 @@ class sfValidatorFDToken
 
   public function asPhp()
   {
-    return sprintf('new %s(%s)', $this->class, implode(', ', array_map(create_function('$a', 'return var_export($a, true);'), $this->arguments)));
+    return sprintf('new %s(%s)', $this->class, implode(', ', array_map(function($a) { return var_export($a, true); }, $this->arguments)));
   }
 
   public function getValidator()
@@ -353,7 +353,7 @@ class sfValidatorFDTokenOperator
       $this->class,
       is_object($tokenLeft) && in_array(get_class($tokenLeft), array('sfValidatorFDToken', 'sfValidatorFDTokenFilter')) ? $tokenLeft->asPhp() : $tokenLeft,
       is_object($tokenRight) && in_array(get_class($tokenRight), array('sfValidatorFDToken', 'sfValidatorFDTokenFilter')) ? $tokenRight->asPhp() : $tokenRight,
-      implode(', ', array_map(create_function('$a', 'return var_export($a, true);'), $this->arguments))
+      implode(', ', array_map(function($a) { return var_export($a, true); }, $this->arguments))
     );
   }
 


### PR DESCRIPTION
This pull replaces `create_function` usages to regular lambda functions (introduced in PHP 5.3) to improve PHP 7.2 compatibility. 

It will fix PHP nightly build compatibility at your Travis-CI output:

![2017-07-30 01-59-48](https://user-images.githubusercontent.com/370680/28749284-db0f1a00-74ca-11e7-9de8-bd4ad98917ad.png)
