### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
@@ -15,6 +13,13 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: nightly
+    include:
+        - php: 5.3
+          dist: precise
+          sudo: required
+        - php: 5.4
+          dist: precise
+          sudo: required
 
 # faster builds on new travis setup not using sudo
 sudo: false


### PR DESCRIPTION
Trusty distro is now the defacto for all builds.
PHP < 5.5 can't properly run on Trusty.
Switching back to Precise for PHP 5.3 & 5.4