### PR TITLE
Allow PATCH as an option in functional tests

### DIFF
--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -272,7 +272,7 @@ abstract class sfBrowserBase
 
     // request parameters
     $_GET = $_POST = array();
-    if (in_array(strtoupper($method), array('POST', 'DELETE', 'PUT')))
+    if (in_array(strtoupper($method), array('POST', 'DELETE', 'PUT', 'PATCH')))
     {
       if (isset($parameters['_with_csrf']) && $parameters['_with_csrf'])
       {


### PR DESCRIPTION
We have some (Vue.js) app code where we use PATCH as a request method, and we needed to make this tweak to sfTestFunctionalBase to be able to test the routes accepting PATCH.