### PR TITLE
Remove typehint from exception handler

### DIFF
--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -480,7 +480,7 @@ abstract class sfTestFunctionalBase
    *
    * @param Exception $exception The exception
    */
-  function handleException(Exception $exception)
+  function handleException($exception)
   {
     $this->test()->error(sprintf('%s: %s', get_class($exception), $exception->getMessage()));
 


### PR DESCRIPTION
This exception handler can be passed Exceptions as well as Errors. In PHP7 those both fall under the parent class 'Throwable', but for PHP5 BC it's advised to just remove the typehint entirely.